### PR TITLE
Allow Toxiproxy Host to be Specified

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 22.2.8
-elixir 1.10.3-otp-22
+erlang 23.2
+elixir 1.11.3-otp-23

--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ README](https://github.com/shopify/toxiproxy#usage).
 
 ## Usage
 
-The Elixir client communicates with the Toxiproxy daemon via HTTP on `http://127.0.0.1:8474`.
+By default the Elixir client communicates with the Toxiproxy daemon via HTTP on `http://127.0.0.1:8474`, but you can point to any host via your application configuration:
+```elixir
+config :toxiproxy_ex, host: "http://toxiproxy.local:8844"
+```
 
 For example, to simulate 1000ms latency on a database server you can use the
 `latency` toxic with the `latency` argument (see the Toxiproxy project for a

--- a/lib/toxiproxy_ex.ex
+++ b/lib/toxiproxy_ex.ex
@@ -25,7 +25,12 @@ defmodule ToxiproxyEx do
   @typedoc """
   A map containing fields required to setup a proxy. Designed to be used with `ToxiproxyEx.populate!/1`.
   """
-  @type proxy_map :: %{required(:name) => String.t(), required(:upstream) => host_with_port(), optional(:listen) => host_with_port(), optional(:enabled) => true | false}
+  @type proxy_map :: %{
+          required(:name) => String.t(),
+          required(:upstream) => host_with_port(),
+          optional(:listen) => host_with_port(),
+          optional(:enabled) => true | false
+        }
 
   @doc """
   Creates a proxy on the toxiproxy server.
@@ -322,7 +327,7 @@ defmodule ToxiproxyEx do
       ...>  nil
       ...> end)
   """
-  @spec apply!(toxic_collection(), (-> any())) :: :ok
+  @spec apply!(toxic_collection(), (() -> any())) :: :ok
   def apply!(%ToxicCollection{toxics: toxics}, fun) do
     dups =
       Enum.group_by(toxics, fn t -> [t.name, t.proxy_name] end)
@@ -381,7 +386,7 @@ defmodule ToxiproxyEx do
       ...>  nil
       ...> end)
   """
-  @spec down!(toxic_collection(), (-> any())) :: :ok
+  @spec down!(toxic_collection(), (() -> any())) :: :ok
   def down!(proxy = %Proxy{}, fun) do
     down!(ToxicCollection.new(proxy), fun)
   end

--- a/lib/toxiproxy_ex/client.ex
+++ b/lib/toxiproxy_ex/client.ex
@@ -52,8 +52,10 @@ defmodule ToxiproxyEx.Client do
   end
 
   defp client() do
+    url = Application.get_env(:toxiproxy_ex, :host, "http://127.0.0.1:8474")
+
     middleware = [
-      {Tesla.Middleware.BaseUrl, "http://127.0.0.1:8474"},
+      {Tesla.Middleware.BaseUrl, url},
       Tesla.Middleware.JSON
     ]
 

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule ToxiproxyEx.MixProject do
       {:castore, "~> 0.1.0"},
       {:mint, "~> 1.0"},
       {:ex_doc, "~> 0.23", only: :dev, runtime: false},
-      {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
+      {:dialyxir, "~> 1.0", only: [:dev], runtime: false}
     ]
   end
 

--- a/test/toxiproxy_ex_test.exs
+++ b/test/toxiproxy_ex_test.exs
@@ -253,11 +253,13 @@ defmodule ToxiproxyExTest do
       ToxiproxyEx.create!(upstream: upstream, listen: "localhost:8888", name: "test_echo_proxy")
 
       %ToxicCollection{proxies: proxies} =
-        ToxiproxyEx.populate!([%{
-          name: "test_echo_proxy",
-          upstream: upstream,
-          listen: "localhost:5555"
-        }])
+        ToxiproxyEx.populate!([
+          %{
+            name: "test_echo_proxy",
+            upstream: upstream,
+            listen: "localhost:5555"
+          }
+        ])
 
       assert Enum.count(proxies) == 1
 
@@ -273,10 +275,12 @@ defmodule ToxiproxyExTest do
       new_upstream = "localhost:#{port2}"
 
       %ToxicCollection{proxies: proxies} =
-        ToxiproxyEx.populate!([%{
-          name: "test_echo_proxy",
-          upstream: new_upstream
-        }])
+        ToxiproxyEx.populate!([
+          %{
+            name: "test_echo_proxy",
+            upstream: new_upstream
+          }
+        ])
 
       assert Enum.count(proxies) == 1
       assert %Proxy{upstream: ^new_upstream, name: "test_echo_proxy"} = hd(proxies)


### PR DESCRIPTION
This patch adds a new Application configuration option that allows changing the Toxiproxy host.

Generally it's not a good idea to use Application configurations for libraries, however there are a few reason why this is what we want here:
- This library must only be used in testing code.

- You should really only ever run one Toxiproxy server, you can even use the same Toxiproxy server for multiple applications, as pointed out in the Toxiproxy docs:

> Should I run a Toxiproxy for each application? No, we recommend using the same Toxiproxy for all applications. To distinguish between services we recommend naming your proxies with the scheme: <app>_<env>_<data store>_<shard>. For example, shopify_test_redis_master or shopify_development_mysql_1.