### PR TITLE
CI, Use Erlang Foundation Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-beam@v1
         with:
-          otp-version: '22.2.8'
-          elixir-version: '1.10.3'
+          otp-version: '23.2'
+          elixir-version: '1.11.3'
       - run: curl --silent -L https://github.com/Shopify/toxiproxy/releases/download/v2.1.2/toxiproxy-server-linux-amd64 -o ./toxiproxy-server
       - run: chmod +x ./toxiproxy-server
       - run: nohup bash -c "./toxiproxy-server > ./toxiproxy.log 2>&1 &"


### PR DESCRIPTION
This patch makes use of the [erlef/setup-beam](https://github.com/erlef/setup-beam) action instead of the [unmaintained one provided by github](https://github.com/actions/setup-elixir).