### PR TITLE
Loosen restriction on minor versions for the tesla dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule ToxiproxyEx.MixProject do
 
   defp deps do
     [
-      {:tesla, "~> 1.7.0"},
+      {:tesla, "~> 1.7"},
       {:jason, ">= 1.0.0"},
       {:castore, "~> 1.0.3"},
       {:mint, "~> 1.0"},


### PR DESCRIPTION
Currently, this library is unusable by applications that use newer minor versions of the Tesla dependency. As far as I can tell, there's nothing preventing this library from using newer versions of Tesla, or perhaps even earlier versions, like 1.3, as was the case prior to the Dependabot bump: https://github.com/Jcambass/toxiproxy_ex/pull/13. I kept it as 1.7 to stay on the conservative side.