### PR TITLE
Loosen Deps Requirements

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,9 +37,9 @@ defmodule ToxiproxyEx.MixProject do
 
   defp deps do
     [
-      {:tesla, "~> 1.15.2"},
-      {:jason, ">= 1.0.0"},
-      {:castore, "~> 1.0.3"},
+      {:tesla, "~> 1.3"},
+      {:jason, "~> 1.0"},
+      {:castore, "~> 1.0"},
       {:mint, "~> 1.0"},
       {:ex_doc, "~> 0.23", only: :dev, runtime: false}
     ] ++


### PR DESCRIPTION
As suggested in https://github.com/Jcambass/toxiproxy_ex/pull/26 we don't require any functionality added by the later versions of these libraries. So, let's help avoiding dependency hell by being liberal with what versions we support.

Closes https://github.com/Jcambass/toxiproxy_ex/pull/26